### PR TITLE
fix: remove leading empty lines from generated cottheme files

### DIFF
--- a/coteditor.tera
+++ b/coteditor.tera
@@ -5,8 +5,8 @@ whiskers:
     - flavor
   filename: "themes/Catppuccin {{flavor.name}}.cottheme"
 ---
-{% set line_highlight = text | mod(opacity=0.1) %}
-{% set selection = overlay2 | mod(opacity=0.20) %}
+{% set line_highlight = text | mod(opacity=0.1) -%}
+{% set selection = overlay2 | mod(opacity=0.20) -%}
 {
   "attributes" : {
     "color" : "#{{yellow.hex}}"

--- a/themes/Catppuccin Frappé.cottheme
+++ b/themes/Catppuccin Frappé.cottheme
@@ -1,5 +1,3 @@
-
-
 {
   "attributes" : {
     "color" : "#e5c890"

--- a/themes/Catppuccin Latte.cottheme
+++ b/themes/Catppuccin Latte.cottheme
@@ -1,5 +1,3 @@
-
-
 {
   "attributes" : {
     "color" : "#df8e1d"

--- a/themes/Catppuccin Macchiato.cottheme
+++ b/themes/Catppuccin Macchiato.cottheme
@@ -1,5 +1,3 @@
-
-
 {
   "attributes" : {
     "color" : "#eed49f"

--- a/themes/Catppuccin Mocha.cottheme
+++ b/themes/Catppuccin Mocha.cottheme
@@ -1,5 +1,3 @@
-
-
 {
   "attributes" : {
     "color" : "#f9e2af"


### PR DESCRIPTION
Prevents unwanted newlines in generated theme files by using {%- -%} syntax around set statements.