### PR TITLE
fix: remove leading empty lines from generated cottheme files

### DIFF
--- a/coteditor.tera
+++ b/coteditor.tera
@@ -5,8 +5,8 @@ whiskers:
     - flavor
   filename: "themes/catppuccin-{{flavor.identifier}}.cottheme"
 ---
-{% set line_highlight = text | mod(opacity=0.1) %}
-{% set selection = overlay2 | mod(opacity=0.20) %}
+{% set line_highlight = text | mod(opacity=0.1) -%}
+{% set selection = overlay2 | mod(opacity=0.20) -%}
 {
   "attributes" : {
     "color" : "#{{yellow.hex}}"

--- a/themes/catppuccin-frappe.cottheme
+++ b/themes/catppuccin-frappe.cottheme
@@ -1,5 +1,3 @@
-
-
 {
   "attributes" : {
     "color" : "#e5c890"

--- a/themes/catppuccin-latte.cottheme
+++ b/themes/catppuccin-latte.cottheme
@@ -1,5 +1,3 @@
-
-
 {
   "attributes" : {
     "color" : "#df8e1d"

--- a/themes/catppuccin-macchiato.cottheme
+++ b/themes/catppuccin-macchiato.cottheme
@@ -1,5 +1,3 @@
-
-
 {
   "attributes" : {
     "color" : "#eed49f"

--- a/themes/catppuccin-mocha.cottheme
+++ b/themes/catppuccin-mocha.cottheme
@@ -1,5 +1,3 @@
-
-
 {
   "attributes" : {
     "color" : "#f9e2af"


### PR DESCRIPTION
- Apply {%- and -%} to set statements to trim whitespace
- Prevents 2 empty lines appearing at the start of generated .cottheme files
- Improves output quality for CotEditor theme generation