### PR TITLE
feat: add accent theme variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@
 
 ## Usage
 
-1. Download the flavor of your choice from the [themes](./themes) directory.
+1. Download the flavor and accent combination of your choice from the [themes](./themes) directory.
 2. Open the app and go to **Settings** > **Appearance**.
 3. Click the **More options button** (⋯) and select **Import...**.
 4. Select the file that you downloaded.
+
+The non-accented theme files use Rosewater as the default accent.
 
 ## 🙋 FAQ
 

--- a/coteditor.tera
+++ b/coteditor.tera
@@ -3,12 +3,14 @@ whiskers:
   version: ^2.5.1
   matrix:
     - flavor
-  filename: "themes/catppuccin-{{flavor.identifier}}.cottheme"
+    - accent
+  filename: "themes/catppuccin-{{flavor.identifier}}-{{accent}}.cottheme"
 ---
+{% set accent_color = flavor.colors[accent] -%}
 {% set line_highlight = text | mod(opacity=0.1) -%}
-{% set selection = overlay2 | mod(opacity=0.20) -%}
+{% set selection = accent_color | mod(opacity=0.40) -%}
 {
-  "name" : "Catppuccin {{flavor.name}}",
+  "name" : "Catppuccin {{flavor.name}} {{accent_color.name}}",
   "metadata" : {
     "author" : "Catppuccin",
     "description" : "Soothing pastel theme for CotEditor",
@@ -26,18 +28,18 @@ whiskers:
     "usesSystemSetting" : false
   },
   "cursor" : {
-    "color" : "#{{rosewater.hex}}",
+    "color" : "#{{accent_color.hex}}",
     "usesSystemSetting" : false
   },
   "lineHighlight" : {
     "color" : "#{{line_highlight.hex}}"
   },
   "insertionPoint" : {
-    "color" : "#{{rosewater.hex}}",
+    "color" : "#{{accent_color.hex}}",
     "usesSystemSetting" : false
   },
   "highlight" : {
-    "color" : "#{{teal.hex}}",
+    "color" : "#{{accent_color.hex}}",
     "usesSystemSetting" : false
   },
   "attributes" : {
@@ -68,7 +70,7 @@ whiskers:
     "color" : "#{{yellow.hex}}"
   },
   "values" : {
-    "color" : "#{{red.hex}}"
+    "color" : "#{{peach.hex}}"
   },
   "variables" : {
     "color" : "#{{maroon.hex}}"

--- a/themes/catppuccin-frappe-blue.cottheme
+++ b/themes/catppuccin-frappe-blue.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Blue",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#8caaee66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#8caaee",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#8caaee",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#8caaee",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-flamingo.cottheme
+++ b/themes/catppuccin-frappe-flamingo.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Flamingo",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#eebebe66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#eebebe",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#eebebe",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#eebebe",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-green.cottheme
+++ b/themes/catppuccin-frappe-green.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Green",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#a6d18966",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#a6d189",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#a6d189",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#a6d189",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-lavender.cottheme
+++ b/themes/catppuccin-frappe-lavender.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Lavender",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#babbf166",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#babbf1",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#babbf1",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#babbf1",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-maroon.cottheme
+++ b/themes/catppuccin-frappe-maroon.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Maroon",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#ea999c66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#ea999c",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#ea999c",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#ea999c",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-mauve.cottheme
+++ b/themes/catppuccin-frappe-mauve.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Mauve",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#ca9ee666",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#ca9ee6",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#ca9ee6",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#ca9ee6",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-peach.cottheme
+++ b/themes/catppuccin-frappe-peach.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Peach",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#ef9f7666",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#ef9f76",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#ef9f76",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#ef9f76",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-pink.cottheme
+++ b/themes/catppuccin-frappe-pink.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Pink",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#f4b8e466",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f4b8e4",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#f4b8e4",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f4b8e4",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-red.cottheme
+++ b/themes/catppuccin-frappe-red.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Red",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#e7828466",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#e78284",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#e78284",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#e78284",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-rosewater.cottheme
+++ b/themes/catppuccin-frappe-rosewater.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Rosewater",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#f2d5cf66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f2d5cf",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#f2d5cf",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f2d5cf",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-sapphire.cottheme
+++ b/themes/catppuccin-frappe-sapphire.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Sapphire",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#85c1dc66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#85c1dc",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#85c1dc",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#85c1dc",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-sky.cottheme
+++ b/themes/catppuccin-frappe-sky.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Sky",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#99d1db66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#99d1db",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#99d1db",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#99d1db",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-teal.cottheme
+++ b/themes/catppuccin-frappe-teal.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Teal",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#81c8be66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#81c8be",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#81c8be",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#81c8be",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-frappe-yellow.cottheme
+++ b/themes/catppuccin-frappe-yellow.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Frappé Yellow",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#303446"
+  },
+  "text" : {
+    "color" : "#c6d0f5"
+  },
+  "selection" : {
+    "color" : "#e5c89066",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#e5c890",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#c6d0f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#e5c890",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#e5c890",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#e5c890"
+  },
+  "characters" : {
+    "color" : "#f4b8e4"
+  },
+  "commands" : {
+    "color" : "#8caaee"
+  },
+  "comments" : {
+    "color" : "#949cbb"
+  },
+  "invisibles" : {
+    "color" : "#737994"
+  },
+  "keywords" : {
+    "color" : "#ca9ee6"
+  },
+  "numbers" : {
+    "color" : "#ef9f76"
+  },
+  "strings" : {
+    "color" : "#a6d189"
+  },
+  "types" : {
+    "color" : "#e5c890"
+  },
+  "values" : {
+    "color" : "#ef9f76"
+  },
+  "variables" : {
+    "color" : "#ea999c"
+  }
+}

--- a/themes/catppuccin-latte-blue.cottheme
+++ b/themes/catppuccin-latte-blue.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Blue",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#1e66f566",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#1e66f5",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#1e66f5",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#1e66f5",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-flamingo.cottheme
+++ b/themes/catppuccin-latte-flamingo.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Flamingo",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#dd787866",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#dd7878",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#dd7878",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#dd7878",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-green.cottheme
+++ b/themes/catppuccin-latte-green.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Green",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#40a02b66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#40a02b",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#40a02b",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#40a02b",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-lavender.cottheme
+++ b/themes/catppuccin-latte-lavender.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Lavender",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#7287fd66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#7287fd",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#7287fd",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#7287fd",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-maroon.cottheme
+++ b/themes/catppuccin-latte-maroon.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Maroon",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#e6455366",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#e64553",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#e64553",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#e64553",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-mauve.cottheme
+++ b/themes/catppuccin-latte-mauve.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Mauve",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#8839ef66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#8839ef",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#8839ef",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#8839ef",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-peach.cottheme
+++ b/themes/catppuccin-latte-peach.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Peach",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#fe640b66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#fe640b",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#fe640b",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#fe640b",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-pink.cottheme
+++ b/themes/catppuccin-latte-pink.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Pink",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#ea76cb66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#ea76cb",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#ea76cb",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#ea76cb",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-red.cottheme
+++ b/themes/catppuccin-latte-red.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Red",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#d20f3966",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#d20f39",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#d20f39",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#d20f39",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-rosewater.cottheme
+++ b/themes/catppuccin-latte-rosewater.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Rosewater",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#dc8a7866",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#dc8a78",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#dc8a78",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#dc8a78",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-sapphire.cottheme
+++ b/themes/catppuccin-latte-sapphire.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Sapphire",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#209fb566",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#209fb5",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#209fb5",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#209fb5",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-sky.cottheme
+++ b/themes/catppuccin-latte-sky.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Sky",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#04a5e566",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#04a5e5",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#04a5e5",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#04a5e5",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-teal.cottheme
+++ b/themes/catppuccin-latte-teal.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Teal",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#17929966",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#179299",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#179299",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#179299",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-latte-yellow.cottheme
+++ b/themes/catppuccin-latte-yellow.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Latte Yellow",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#eff1f5"
+  },
+  "text" : {
+    "color" : "#4c4f69"
+  },
+  "selection" : {
+    "color" : "#df8e1d66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#df8e1d",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#4c4f691a"
+  },
+  "insertionPoint" : {
+    "color" : "#df8e1d",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#df8e1d",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#df8e1d"
+  },
+  "characters" : {
+    "color" : "#ea76cb"
+  },
+  "commands" : {
+    "color" : "#1e66f5"
+  },
+  "comments" : {
+    "color" : "#7c7f93"
+  },
+  "invisibles" : {
+    "color" : "#9ca0b0"
+  },
+  "keywords" : {
+    "color" : "#8839ef"
+  },
+  "numbers" : {
+    "color" : "#fe640b"
+  },
+  "strings" : {
+    "color" : "#40a02b"
+  },
+  "types" : {
+    "color" : "#df8e1d"
+  },
+  "values" : {
+    "color" : "#fe640b"
+  },
+  "variables" : {
+    "color" : "#e64553"
+  }
+}

--- a/themes/catppuccin-macchiato-blue.cottheme
+++ b/themes/catppuccin-macchiato-blue.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Blue",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#8aadf466",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#8aadf4",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#8aadf4",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#8aadf4",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-flamingo.cottheme
+++ b/themes/catppuccin-macchiato-flamingo.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Flamingo",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#f0c6c666",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f0c6c6",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#f0c6c6",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f0c6c6",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-green.cottheme
+++ b/themes/catppuccin-macchiato-green.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Green",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#a6da9566",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#a6da95",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#a6da95",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#a6da95",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-lavender.cottheme
+++ b/themes/catppuccin-macchiato-lavender.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Lavender",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#b7bdf866",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#b7bdf8",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#b7bdf8",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#b7bdf8",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-maroon.cottheme
+++ b/themes/catppuccin-macchiato-maroon.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Maroon",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#ee99a066",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#ee99a0",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#ee99a0",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#ee99a0",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-mauve.cottheme
+++ b/themes/catppuccin-macchiato-mauve.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Mauve",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#c6a0f666",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#c6a0f6",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#c6a0f6",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#c6a0f6",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-peach.cottheme
+++ b/themes/catppuccin-macchiato-peach.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Peach",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#f5a97f66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f5a97f",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#f5a97f",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f5a97f",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-pink.cottheme
+++ b/themes/catppuccin-macchiato-pink.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Pink",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#f5bde666",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f5bde6",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#f5bde6",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f5bde6",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-red.cottheme
+++ b/themes/catppuccin-macchiato-red.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Red",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#ed879666",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#ed8796",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#ed8796",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#ed8796",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-rosewater.cottheme
+++ b/themes/catppuccin-macchiato-rosewater.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Rosewater",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#f4dbd666",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f4dbd6",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#f4dbd6",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f4dbd6",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-sapphire.cottheme
+++ b/themes/catppuccin-macchiato-sapphire.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Sapphire",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#7dc4e466",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#7dc4e4",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#7dc4e4",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#7dc4e4",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-sky.cottheme
+++ b/themes/catppuccin-macchiato-sky.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Sky",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#91d7e366",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#91d7e3",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#91d7e3",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#91d7e3",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-teal.cottheme
+++ b/themes/catppuccin-macchiato-teal.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Teal",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#8bd5ca66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#8bd5ca",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#8bd5ca",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#8bd5ca",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-macchiato-yellow.cottheme
+++ b/themes/catppuccin-macchiato-yellow.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Macchiato Yellow",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#24273a"
+  },
+  "text" : {
+    "color" : "#cad3f5"
+  },
+  "selection" : {
+    "color" : "#eed49f66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#eed49f",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cad3f51a"
+  },
+  "insertionPoint" : {
+    "color" : "#eed49f",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#eed49f",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#eed49f"
+  },
+  "characters" : {
+    "color" : "#f5bde6"
+  },
+  "commands" : {
+    "color" : "#8aadf4"
+  },
+  "comments" : {
+    "color" : "#939ab7"
+  },
+  "invisibles" : {
+    "color" : "#6e738d"
+  },
+  "keywords" : {
+    "color" : "#c6a0f6"
+  },
+  "numbers" : {
+    "color" : "#f5a97f"
+  },
+  "strings" : {
+    "color" : "#a6da95"
+  },
+  "types" : {
+    "color" : "#eed49f"
+  },
+  "values" : {
+    "color" : "#f5a97f"
+  },
+  "variables" : {
+    "color" : "#ee99a0"
+  }
+}

--- a/themes/catppuccin-mocha-blue.cottheme
+++ b/themes/catppuccin-mocha-blue.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Blue",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#89b4fa66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#89b4fa",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#89b4fa",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#89b4fa",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-flamingo.cottheme
+++ b/themes/catppuccin-mocha-flamingo.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Flamingo",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#f2cdcd66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f2cdcd",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#f2cdcd",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f2cdcd",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-green.cottheme
+++ b/themes/catppuccin-mocha-green.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Green",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#a6e3a166",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#a6e3a1",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#a6e3a1",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#a6e3a1",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-lavender.cottheme
+++ b/themes/catppuccin-mocha-lavender.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Lavender",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#b4befe66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#b4befe",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#b4befe",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#b4befe",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-maroon.cottheme
+++ b/themes/catppuccin-mocha-maroon.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Maroon",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#eba0ac66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#eba0ac",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#eba0ac",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#eba0ac",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-mauve.cottheme
+++ b/themes/catppuccin-mocha-mauve.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Mauve",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#cba6f766",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#cba6f7",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#cba6f7",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#cba6f7",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-peach.cottheme
+++ b/themes/catppuccin-mocha-peach.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Peach",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#fab38766",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#fab387",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#fab387",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#fab387",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-pink.cottheme
+++ b/themes/catppuccin-mocha-pink.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Pink",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#f5c2e766",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f5c2e7",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#f5c2e7",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f5c2e7",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-red.cottheme
+++ b/themes/catppuccin-mocha-red.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Red",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#f38ba866",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f38ba8",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#f38ba8",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f38ba8",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-rosewater.cottheme
+++ b/themes/catppuccin-mocha-rosewater.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Rosewater",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#f5e0dc66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f5e0dc",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#f5e0dc",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f5e0dc",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-sapphire.cottheme
+++ b/themes/catppuccin-mocha-sapphire.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Sapphire",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#74c7ec66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#74c7ec",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#74c7ec",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#74c7ec",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-sky.cottheme
+++ b/themes/catppuccin-mocha-sky.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Sky",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#89dceb66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#89dceb",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#89dceb",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#89dceb",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-teal.cottheme
+++ b/themes/catppuccin-mocha-teal.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Teal",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#94e2d566",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#94e2d5",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#94e2d5",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#94e2d5",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}

--- a/themes/catppuccin-mocha-yellow.cottheme
+++ b/themes/catppuccin-mocha-yellow.cottheme
@@ -1,0 +1,67 @@
+{
+  "name" : "Catppuccin Mocha Yellow",
+  "metadata" : {
+    "author" : "Catppuccin",
+    "description" : "Soothing pastel theme for CotEditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
+    "license" : "MIT"
+  },
+  "background" : {
+    "color" : "#1e1e2e"
+  },
+  "text" : {
+    "color" : "#cdd6f4"
+  },
+  "selection" : {
+    "color" : "#f9e2af66",
+    "usesSystemSetting" : false
+  },
+  "cursor" : {
+    "color" : "#f9e2af",
+    "usesSystemSetting" : false
+  },
+  "lineHighlight" : {
+    "color" : "#cdd6f41a"
+  },
+  "insertionPoint" : {
+    "color" : "#f9e2af",
+    "usesSystemSetting" : false
+  },
+  "highlight" : {
+    "color" : "#f9e2af",
+    "usesSystemSetting" : false
+  },
+  "attributes" : {
+    "color" : "#f9e2af"
+  },
+  "characters" : {
+    "color" : "#f5c2e7"
+  },
+  "commands" : {
+    "color" : "#89b4fa"
+  },
+  "comments" : {
+    "color" : "#9399b2"
+  },
+  "invisibles" : {
+    "color" : "#6c7086"
+  },
+  "keywords" : {
+    "color" : "#cba6f7"
+  },
+  "numbers" : {
+    "color" : "#fab387"
+  },
+  "strings" : {
+    "color" : "#a6e3a1"
+  },
+  "types" : {
+    "color" : "#f9e2af"
+  },
+  "values" : {
+    "color" : "#fab387"
+  },
+  "variables" : {
+    "color" : "#eba0ac"
+  }
+}


### PR DESCRIPTION
## Summary
- generate CotEditor themes for all Catppuccin flavor/accent combinations
- use the selected accent for cursor and insertion point colors
- document flavor/accent selection in the README

## Validation
- cargo run --manifest-path ../whiskers-main/whiskers-main/Cargo.toml -- coteditor.tera --check
- verified 56 generated accent variant files